### PR TITLE
Add table unit test

### DIFF
--- a/internal/core/services/portsprotocol/portsprotocol_fake.go
+++ b/internal/core/services/portsprotocol/portsprotocol_fake.go
@@ -9,6 +9,45 @@ import (
 	grpc "google.golang.org/grpc"
 )
 
+var FakePorts = map[string]*domain.Port{
+	"fakePort": {
+		Name:        "fakeName",
+		City:        "fakeCity",
+		Country:     "fakeCountry",
+		Alias:       []string{"fakeAlias"},
+		Regions:     []string{"fakeregion"},
+		Coordinates: []float32{11.111, 22.222},
+		Province:    "fakeProvince",
+		Timezone:    "fakeTimezone",
+		Unlocs:      []string{"fakeUnlock"},
+		Code:        "fakeCode",
+	},
+	"fakePort2": {
+		Name:        "fakeName2",
+		City:        "fakeCity2",
+		Country:     "fakeCountry2",
+		Alias:       []string{},
+		Regions:     []string{"fakeregion2"},
+		Coordinates: []float32{33, 44},
+		Province:    "fakeProvince2",
+		Timezone:    "fakeTimezone2",
+		Unlocs:      []string{},
+		Code:        "fakeCode2",
+	},
+	"fakePort3": {
+		Name:        "fakeName3",
+		City:        "fakeCity2",
+		Country:     "fakeCountry2",
+		Alias:       []string{"fakeAliasX", "fakeAliasY"},
+		Regions:     []string{"fakeregionX", "fakeRegionY"},
+		Coordinates: []float32{12.765, 22.908},
+		Province:    "fakeProvince3",
+		Timezone:    "fakeTimezone3",
+		Unlocs:      []string{"fakeUnlock", "fakeUnlock2"},
+		Code:        "fakeCode3",
+	},
+}
+
 // FakePort is used for returning non-empty response from fakePortServiceClient.GetPort(_)
 var FakePort = domain.Port{
 	Name:        "fakeName",
@@ -39,10 +78,10 @@ func (c *fakePortServiceClient) CreateOrUpdatePort(ctx context.Context, in *doma
 // GetPort is used to return FakePort as fake response for testing purposes
 func (c *fakePortServiceClient) GetPort(ctx context.Context, in *domain.GetPortRequest, opts ...grpc.CallOption) (*domain.GetPortResponse, error) {
 	log.Info("GetPort ", in.Key, " port with fake grpc pb client")
-	if in.Key == "fakePort" {
+	if _, ok := FakePorts[in.Key]; ok {
 		log.Info("Returning fakePort with fake values.")
 		return &domain.GetPortResponse{
-			Port: &FakePort,
+			Port: FakePorts[in.Key],
 		}, nil
 	} else {
 		log.Info("Returning empty fakePort.")

--- a/internal/handlers/restapi_test.go
+++ b/internal/handlers/restapi_test.go
@@ -2,6 +2,8 @@ package handlers_test
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 
@@ -12,20 +14,12 @@ import (
 	"github.com/Dysproz/ports-db-microservices/internal/core/services/portsprotocol"
 	"github.com/Dysproz/ports-db-microservices/internal/handlers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestHandleGetPort(t *testing.T) {
-	client := handlers.NewRESTClient(
-		portsprotocol.NewFakePortServiceClient(),
-		jsonparser.NewStream(),
-	)
-	var jsonPayload = []byte(`{"key":"fakePort"}`)
-	req := httptest.NewRequest("POST", "http://example.com/getPort", bytes.NewBuffer(jsonPayload))
-	req.Header.Set("Content-Type", "application/json")
-	w := httptest.NewRecorder()
-	handler := http.HandlerFunc(client.HandleGetPort)
-	handler.ServeHTTP(w, req)
-	assert.NotEqual(t, w.Code, http.StatusInternalServerError)
+type getPortTest struct {
+	key          string
+	expectedPort domain.Port
 }
 
 var testPort = domain.Port{
@@ -39,6 +33,56 @@ var testPort = domain.Port{
 	Timezone:    "fakeTimezone",
 	Unlocs:      []string{"fakeUnlock"},
 	Code:        "fakeCode",
+}
+
+var testPort2 = domain.Port{
+	Name:        "fakeName2",
+	City:        "fakeCity2",
+	Country:     "fakeCountry2",
+	Alias:       nil,
+	Regions:     []string{"fakeregion2"},
+	Coordinates: []float32{33, 44},
+	Province:    "fakeProvince2",
+	Timezone:    "fakeTimezone2",
+	Unlocs:      nil,
+	Code:        "fakeCode2",
+}
+
+var testPort3 = domain.Port{
+	Name:        "fakeName3",
+	City:        "fakeCity2",
+	Country:     "fakeCountry2",
+	Alias:       []string{"fakeAliasX", "fakeAliasY"},
+	Regions:     []string{"fakeregionX", "fakeRegionY"},
+	Coordinates: []float32{12.765, 22.908},
+	Province:    "fakeProvince3",
+	Timezone:    "fakeTimezone3",
+	Unlocs:      []string{"fakeUnlock", "fakeUnlock2"},
+	Code:        "fakeCode3",
+}
+
+func TestHandleGetPort(t *testing.T) {
+	tests := []getPortTest{
+		{key: "fakePort", expectedPort: testPort},
+		{key: "fakePort2", expectedPort: testPort2},
+		{key: "fakePort3", expectedPort: testPort3},
+	}
+	client := handlers.NewRESTClient(
+		portsprotocol.NewFakePortServiceClient(),
+		jsonparser.NewStream(),
+	)
+	for _, tc := range tests {
+		var jsonPayload = []byte(fmt.Sprintf(`{"key":"%v"}`, tc.key))
+		req := httptest.NewRequest("POST", "http://example.com/getPort", bytes.NewBuffer(jsonPayload))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		handler := http.HandlerFunc(client.HandleGetPort)
+		handler.ServeHTTP(w, req)
+		assert.NotEqual(t, w.Code, http.StatusInternalServerError)
+		var resultPort domain.Port
+		require.NoError(t, json.NewDecoder(w.Result().Body).Decode(&resultPort))
+		assert.Equal(t, resultPort, tc.expectedPort)
+	}
 }
 
 func TestHandleLoadPorts(t *testing.T) {


### PR DESCRIPTION
This PR refers to issue #5.

This PR adds table unit test for checking gathering ports from the server.
There 3 test ports and using a table driven tests one of the ports are gathered and then it's value is evaluated against expected outcome. 